### PR TITLE
fix(rest-api-model-sever): make example runnable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,15 +10,18 @@ specificlanguagesMps = "1.5.0"
 mpsGradlePlugin = "1.7.288.4ea765f"
 
 # modelix
-modelixCore = "2.16.0"
+modelixCore = "2.16.3"
 mpsModelServerSyncPlugin = "2021.2.145"
 
 # backend 1 / SPA
 ktor = "2.3.3"
 
 # backend 2
-quarkusPlatform = "2.14.0.Final"
-quarkusPlugin = "2.14.0.Final"
+# When increasing the version of quarkus,
+# see if you can raise the version of the Kotlin API used by the generated code
+# in mps/metamodel-api-kts/build.gradle.kts
+quarkusPlatform = "2.16.9.Final"
+quarkusPlugin = "2.16.9.Final"
 
 # other
 openapi = "6.6.0"

--- a/mps/metamodel-api-kts/build.gradle.kts
+++ b/mps/metamodel-api-kts/build.gradle.kts
@@ -5,3 +5,13 @@ plugins {
 dependencies {
     api(libs.modelix.model.api.gen.runtime)
 }
+
+kotlin {
+    compilerOptions {
+        // Only use features from Kotlin 1.7.
+        // This is the version used by the used Quarkus release.
+        // It ensures, that the generated code can be used by Quarkus.
+        // see. https://quarkus.io/version/main/guides/kotlin#kotlin-version
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_7)
+    }
+}


### PR DESCRIPTION
* Use Modelix version that runs with the Kotlin API version specified by Quarkus
* Specify Kotlin API version for generated code