### PR TITLE
chore(rest-api-model-server): update dependency declaration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,6 @@ modelix-light-model-client = { group = "org.modelix", name = "light-model-client
 quarkus-bom = { group = "io.quarkus.platform", name = "quarkus-bom", version.ref = "quarkusPlatform" }
 
 # kotlin/ktor
-kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 ktor-server-default-headers = { group = "io.ktor", name = "ktor-server-default-headers", version.ref = "ktor" }
 ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-auto-head-response = { group = "io.ktor", name = "ktor-server-auto-head-response", version.ref = "ktor" }

--- a/rest-api-model-server/build.gradle.kts
+++ b/rest-api-model-server/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 }
 
 dependencies {
+    // The version of the Kotlin stdlib included
+    // by libs.plugins.kotlin.jvm and libs.modelix.model.client
+    // is overridden by the version from the Quarkus platform.
     implementation(enforcedPlatform(libs.quarkus.bom))
     implementation("io.quarkus:quarkus-resteasy-reactive")
     implementation("io.quarkus:quarkus-kotlin")
@@ -18,7 +21,6 @@ dependencies {
 
     implementation(libs.ktor.client.core)
     implementation(libs.modelix.model.client)
-    implementation(libs.kotlin.stdlib)
 
     implementation(project(":mps:metamodel-api-kts"))
 }


### PR DESCRIPTION
Explain Quarkus platform overriding Kotlin versions.

Remove unneeded explicit declaration of Kotlin stdlib. It is automatically added, by the Kotlin Gradle plugin. see. https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library