### PR TITLE
Revert "Bump de.itemis.mps:extensions from 2021.2.2569.a5e1b8d to 2022.3.2653.6ae0559"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 [versions]
 # MPS
 mpsBase = "2021.2.6"
-mpsExtensions = "2022.3.2653.6ae0559"
+mpsExtensions = "2021.2.2569.a5e1b8d"
 specificlanguagesMps = "1.5.0"
 mpsGradlePlugin = "1.7.288.4ea765f"
 


### PR DESCRIPTION
Reverts modelix/modelix.samples#178. We are stuck on 2021