### PR TITLE
fix(rest-api-model-server): fix compability

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.10" />
+    <option name="version" value="1.9.20" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -7,6 +7,7 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mps/metamodel/modelix-samples.mps.metamodel.main.iml" filepath="$PROJECT_DIR$/.idea/modules/mps/metamodel/modelix-samples.mps.metamodel.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mps/project-modelserver-backend/modelix-samples.mps.project-modelserver-backend.iml" filepath="$PROJECT_DIR$/.idea/modules/mps/project-modelserver-backend/modelix-samples.mps.project-modelserver-backend.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mps/project-mps-backend/modelix-samples.mps.project-mps-backend.iml" filepath="$PROJECT_DIR$/.idea/modules/mps/project-mps-backend/modelix-samples.mps.project-mps-backend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/rest-api-model-server/modelix-samples.rest-api-model-server.test.iml" filepath="$PROJECT_DIR$/.idea/modules/rest-api-model-server/modelix-samples.rest-api-model-server.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/spa-dashboard-angular/modelix-samples.spa-dashboard-angular.iml" filepath="$PROJECT_DIR$/.idea/modules/spa-dashboard-angular/modelix-samples.spa-dashboard-angular.iml" />
     </modules>
   </component>

--- a/.idea/modules/rest-api-model-server/modelix-samples.rest-api-model-server.test.iml
+++ b/.idea/modules/rest-api-model-server/modelix-samples.rest-api-model-server.test.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../rest-api-model-server/src/test" dumb="true">
+      <sourceFolder url="file://$MODULE_DIR$/../../../rest-api-model-server/src/test/kotlin" isTestSource="true" />
+    </content>
+  </component>
+</module>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ modelixCore = "3.11.0"
 mpsModelServerSyncPlugin = "2021.2.157"
 
 # backend 1 / SPA
-ktor = "2.3.5"
+ktor = "2.3.6"
 
 # backend 2
 # When increasing the version of quarkus,
@@ -67,6 +67,9 @@ ktor-server-cors = { group = "io.ktor", name = "ktor-server-cors", version.ref =
 ktor-server-websockets = { group = "io.ktor", name = "ktor-server-websockets", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
+ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 # other
 ant-junit = { group = "org.apache.ant", name = "ant-junit", version.ref = "antJunit" }

--- a/rest-api-model-server/build.gradle.kts
+++ b/rest-api-model-server/build.gradle.kts
@@ -19,8 +19,26 @@ dependencies {
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")
 
-    implementation(libs.ktor.client.core)
     implementation(libs.modelix.model.client)
+    implementation(libs.ktor.client.core)
+    constraints {
+        // The Ktor version 2.3.5 from the modelix release 23.2,
+        // has a bug that makes it break for Quarkus.
+        //
+        // The bug stems from an upgraded Kotlin version,
+        // which broke backward compatibility.
+        // See https://youtrack.jetbrains.com/issue/KTOR-6354
+        //
+        // The Ktor version 2.3.6 provides a fix,
+        // but that Ktor version is not used in modelix release 23.2.
+        //
+        // Because of that, we are explicitly constraining the Ktor version
+        // of Ktor libraries to 2.3.6 or later (specified in libs.version.toml)
+        implementation(libs.ktor.client.cio)
+        implementation(libs.ktor.client.auth)
+        implementation(libs.ktor.client.content.negotiation)
+        implementation(libs.ktor.serialization.json)
+    }
 
     implementation(project(":mps:metamodel-api-kts"))
 }

--- a/rest-api-model-server/src/test/kotlin/ReplicatedRepositoryInstantiationTest.kt
+++ b/rest-api-model-server/src/test/kotlin/ReplicatedRepositoryInstantiationTest.kt
@@ -1,0 +1,40 @@
+package org.acme.getting.started.testing
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.modelix.model.client.ReplicatedRepository
+import javax.inject.Inject
+
+class UnreachableUrlProfile : QuarkusTestProfile {
+    override fun getConfigOverrides(): Map<String, String> {
+        // Override the server uri to be an unreachable URL.
+        return mapOf("modelix.client.server-uri" to "http://non_existing_host:93939")
+    }
+}
+
+@QuarkusTest
+@TestProfile(value = UnreachableUrlProfile::class)
+class ReplicatedRepositoryInstantiationTest {
+    @Inject
+    lateinit var replicatedRepository: ReplicatedRepository
+
+    @Test
+    fun testInjection() {
+        // This tests, whether `replicatedRepository` can be correctly injected and instantiated by Quarkus.
+        // The actual instantiation is happening when we call something on `replicatedRepository`.
+        // Therefore, we call `.branch`.
+        // The asserted exception message indicates that the `replicatedRepository` was injected correctly.
+        // The exception message "java.lang.NoClassDefFoundError: kotlin/enums/EnumEntriesKt", for example,
+        // would indicate that something is set up wrong and the instantiation is failing.
+        // In the past, we had such issues with the wrong version of Kotlin and Ktor.
+        val exception = assertThrows(RuntimeException::class.java) { replicatedRepository.branch }
+        assertEquals(
+            "Unable to connect to 'http://non_existing_host:93939/get/branch_courses_master' to get key branch_courses_master",
+            exception.message
+        )
+    }
+}


### PR DESCRIPTION
See comments in the changed file for details.

The problem is, that we want to use the platform release and that the platform release has broken (for some cases, like our Quarkus case) Ktor version.

The issue arises because of an older Quarkus version, which needs an older Kotlin version. 