### PR TITLE
chore: bump modelix-core to 4.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ mpsGradlePlugin = "1.7.288.4ea765f"
 # * mps/metamodel-api-ts/package.json
 # * spa-management-vue/package.json
 # * spa-overview-angular/package.json
-modelixCore = "4.5.0"
+modelixCore = "4.6.0"
 mpsModelServerSyncPlugin = "2021.2.157"
 
 # backend 1 / SPA


### PR DESCRIPTION
In order to roll out https://github.com/modelix/modelix.core/pull/486 to samples and fix https://issues.modelix.org/issue/MODELIX-743 there.